### PR TITLE
Updated links to GitHub

### DIFF
--- a/pages/docs/additional.md
+++ b/pages/docs/additional.md
@@ -5,7 +5,7 @@ permalink: /docs/additional
 ---
 
 ## [Community]({{ '/community.html' | prepend: site.baseurl }})
-- [Meetings](https://gitlab.com/opendatahub/opendatahub-community) -- Community meetings for Open Data Hub are conducted regularly.  Get the meeting information and find out more on the Open Data Hub Community Repo.
+- [Meetings](https://github.com/opendatahub-io/opendatahub-community) -- Community meetings for Open Data Hub are conducted regularly.  Get the meeting information and find out more on the Open Data Hub Community Repo.
 - [GitHub]({{site.repo}}) -- All Open Data Hub projects are open source.  Browse the source code.
 - [Mailing List]({{ site.email_list }}) -- Stay up to date with the latest announcements and discussion about the Open Data Hub.
 <!--- Slack-->

--- a/pages/docs/getting-started/beta/basic-tutorial.md
+++ b/pages/docs/getting-started/beta/basic-tutorial.md
@@ -11,7 +11,7 @@ This Tutorial requires a basic installation of Open Data Hub with Spark and Jupy
 
 All screenshots and instructions are from OpenShift 4.4.  For the purposes of this tutorial, we used [try.openshift.com](https://try.openshift.com/) on AWS.  Tutorials have also been tested on [Code Ready Containers](https://code-ready.github.io/crc/) with 16GB of RAM.
 
-The [source]({{site.repo}}/opendatahub.io/blob/master/assets/files/tutorials/basic/basic_tutorial_notebook.ipynb) for the following notebook is available in GitLab with comments for easy viewing.
+The [source]({{site.repo}}/opendatahub.io/blob/master/assets/files/tutorials/basic/basic_tutorial_notebook.ipynb) for the following notebook is available in GitHub with comments for easy viewing.
 
 ### Exploring JupyterHub and Spark
 

--- a/pages/docs/getting-started/legacy/basic-tutorial.md
+++ b/pages/docs/getting-started/legacy/basic-tutorial.md
@@ -16,7 +16,7 @@ This Tutorial requires a basic installation of Open Data Hub with Spark and Jupy
 
 All screenshots and instructions are from OpenShift 4.2.  For the purposes of this tutorial, we used [try.openshift.com](https://try.openshift.com/) on AWS.  Tutorials have also been tested on [Code Ready Containers](https://code-ready.github.io/crc/) with 16GB of RAM.
 
-The [source]({{site.repo}}/opendatahub.io/blob/master/assets/files/tutorials/basic/basic_tutorial_notebook.ipynb) for the following notebook is available in GitLab with comments for easy viewing.
+The [source]({{site.repo}}/opendatahub.io/blob/master/assets/files/tutorials/basic/basic_tutorial_notebook.ipynb) for the following notebook is available in GitHub with comments for easy viewing.
 
 ### Exploring JupyterHub and Spark
 


### PR DESCRIPTION
The following was changed:
- Updated link in `additional.md` from GitLab to GitHub
- Updated the wording from GitLab to GitHub in `basis-tutorial.md`(s)