### PR TITLE
Fix kubeflow/manifest kfdef link

### DIFF
--- a/_posts/2021-02-02-odh-release-1.0.0-blog.md
+++ b/_posts/2021-02-02-odh-release-1.0.0-blog.md
@@ -13,8 +13,8 @@ Open Data Hub 1.0.0 brings in many new features and components. Components from 
 Legacy option for installing ODH has been removed as the team focuses on ODH Beta where all the new features and bug fixes will be included moving forward. 
 An important note to users, ODH 1.0 includes three example KFDefs for installation on OpenShift 4.3 (or later) :
 1. ODH components [KFDef](https://raw.githubusercontent.com/opendatahub-io/odh-manifests/master/kfdef/kfctl_openshift.yaml)
-2. Kubeflow 1.2 [KFDef](https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_openshift.v1.2.0.yaml)
-3. Kubeflow from master that included KF Serving and KF Pipeline on Tekton [KFDef](https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_openshift.master.kfptekton.yaml)
+2. Kubeflow 1.2 [KFDef](https://raw.githubusercontent.com/kubeflow/manifests/master/distributions/kfdef/kfctl_openshift.v1.2.0.yaml)
+3. Kubeflow from master that included KF Serving and KF Pipeline on Tekton [KFDef](https://raw.githubusercontent.com/kubeflow/manifests/master/distributions/kfdef/kfctl_openshift.master.kfptekton.yaml)
 
 For detailed information on Kubeflow v1.2 components please visit the official Kubeflow 1.2 release [blog](https://blog.kubeflow.org/release/official/2020/11/18/kubeflow-1.2-blog-post.html)
 

--- a/pages/docs/kubeflow/installation.md
+++ b/pages/docs/kubeflow/installation.md
@@ -43,7 +43,7 @@ To install Kubeflow on OpenShift 4.2(or later) please follow the steps below:
 
 1. After the Open Data Hub operator is installed, follow the steps to `Create a New Open Data Hub Deployment` in the Open Data Hub [Quick Installation](../getting-started/quick-installation.html#create-a-new-open-data-hub-deployment) guide.
 
-   **NOTE**: During these steps, you will need to use the [kfctl_openshift_<versionnumber>.yaml](https://github.com/kubeflow/manifests/tree/master/kfdef) KfDef in the kubeflow/manifests repo that we have curated specifically for installing Kubeflow. Additionally, you will need to create the Open Data Hub instance in the namespace `kubeflow`.
+   **NOTE**: During these steps, you will need to use the [kfctl_openshift_*.yaml](https://github.com/kubeflow/manifests/tree/master/distributions/kfdef) KfDef in the kubeflow/manifests repo that we have curated specifically for installing Kubeflow. Additionally, you will need to create the Open Data Hub instance in the namespace `kubeflow`.
 
 1. Verify installation
     ```bash


### PR DESCRIPTION
Pull request for issue #9. Kubeflow did a [project restructure](https://github.com/kubeflow/manifests/pull/1739), which caused the link to break.

Changes in this pull request:
1. Updated to new link.
2. Fixed markdown, so that it displays correctly:
![Screenshot 2021-04-04 at 16 45 29](https://user-images.githubusercontent.com/16334194/113512717-30088680-9566-11eb-9dbd-8c12b19a61f9.png)
