### PR TITLE
Fix DS Pipelines version in the release notes

### DIFF
--- a/pages/docs/roadmap/release-notes.md
+++ b/pages/docs/roadmap/release-notes.md
@@ -12,7 +12,7 @@ style_class: release-notes
 | [Open Data Hub Dashboard](https://github.com/opendatahub-io/odh-dashboard) | v2.5.2 | Dashboard |
 | [Open Data Hub Notebook Images](https://github.com/opendatahub-io/notebooks) | v1.3.1 | Jupyter |
 | [Model Mesh Serving](https://github.com/opendatahub-io/modelmesh-serving) | v0.9.0 | AI/ML |
-| [Data Science Pipelines](https://github.com/opendatahub-io/data-science-pipelines) | v1.2.1 | Data Science Tools |
+| [Data Science Pipelines](https://github.com/opendatahub-io/data-science-pipelines) | v1.3.1 | Data Science Tools |
 {:class="table table-bordered"}
 
 ### Open Data Hub version v1.4.0 - October 2022
@@ -21,7 +21,7 @@ style_class: release-notes
 |--|--|--|--|
 | [Open Data Hub Dashboard](https://github.com/opendatahub-io/odh-dashboard) | v2.2.1 | Dashboard |
 | [Model Mesh Serving](https://github.com/opendatahub-io/modelmesh-serving) | v0.9.0 | AI/ML |
-| [Data Science Pipelines](https://github.com/opendatahub-io/data-science-pipelines) | v1.2.1 | Data Science Tools |
+| [Data Science Pipelines](https://github.com/opendatahub-io/data-science-pipelines) | v1.3.1 | Data Science Tools |
 {:class="table table-bordered"}
 
 ### Open Data Hub version v1.3.0 - July 2022


### PR DESCRIPTION
Fixes an error where the DS Pipelines version was incorrectly updated to 1.3.1

Closes #55 

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>
