### PR TITLE
Add blog post for new DSP Documentation

### DIFF
--- a/_posts/2023-02-06-docs-datascienceprojects.md
+++ b/_posts/2023-02-06-docs-datascienceprojects.md
@@ -1,0 +1,15 @@
+---
+layout: blog
+author: ezidav
+title:  New documentation for Data Science Projects added
+preview: Added New Data Science Project documentation
+date: 2023-02-06
+categories: features, release, documentation
+---
+
+New documentation has been added for the new Data Science Projects feature in the ODH dashboard,the documentation covers the following items:
+* Creating and importing notebooks
+* Collaborating on notebooks using Git
+* Working on data science projects
+* Model serving on Open Data Hub
+* Troubleshooting


### PR DESCRIPTION
This PR adds a new blog to publicize the DSP documentation so that it appears on the news page.