### PR TITLE
Fix Adminstration link on Documentation after Getting Started #61

### DIFF
--- a/pages/docs/getting-started/beta/quick-installation.md
+++ b/pages/docs/getting-started/beta/quick-installation.md
@@ -120,4 +120,4 @@ The Open Data Hub operator will create new Open Data Hub deployments and manage 
 1. Verify the installation by viewing the project workload.  The [ODH Core components]({{site.baseurl}}/docs/tiered-components.html) should be running.
 ![Verify Status]({{site.baseurl}}/assets/img/pages/docs/quick-installation/verify-install.png "Verify Status")
 
-{% include next-link.html label="Administration" url="/docs/administration/installation-customization/customization.html" %}
+{% include next-link.html label="Working On Data Science Projects" url="/docs/working-on-data-science-projects.html" %}

--- a/pages/docs/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/pages/docs/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -43,6 +43,7 @@ You might have run out of storage space on your notebook server.
 .Resolution
 Contact your administrator so that they can perform further checks.
 
+{% include next-link.html label="Administration" url="/docs/administration/installation-customization/customization.html" %}
 
 // [role='_additional-resources']
 // == Additional resources


### PR DESCRIPTION
I have changed the "next" link after Getting started to link the new pages [Data Science Projects](https://opendatahub.io/docs/working-on-data-science-projects.html) and update the [Data Science Projects](https://opendatahub.io/docs/working-on-data-science-projects.html) and add the "next" page [Administration](https://opendatahub.io/docs/administration/installation-customization/customization.html).

Closes #61