### PR TITLE
Add Installation to the page footer

### DIFF
--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -21,6 +21,9 @@ export const Footer = () => {
               <b>QUICK LINKS</b>
             </StackItem>
             <StackItem>
+              <Link to="/docs/quick-installation/">Installation</Link>
+            </StackItem>
+            <StackItem>
               <Link to="/docs/getting-started-with-open-data-hub">Get Started</Link>
             </StackItem>
             <StackItem>


### PR DESCRIPTION
## Description
Adds a Quick Link to the Installation docs on the page footer to support clear access for new users to 

## How Has This Been Tested?
Deployed locally with no issues

![ps_20230613092213](https://github.com/opendatahub-io/opendatahub.io/assets/2432396/c48adfb1-35df-4139-a15f-cfbee9dd4aad)
