### PR TITLE
Update odh 1.9.0 announcement with odh-operator v2.0 note

### DIFF
--- a/src/content/blog/2023-08-12-odh-release-1.9.0-blog.md
+++ b/src/content/blog/2023-08-12-odh-release-1.9.0-blog.md
@@ -20,12 +20,7 @@ Changes included in the Open Data Hub v1.9.0 release:
 * Distributed Workloads [v0.1.0](https://github.com/opendatahub-io/distributed-workloads/releases/tag/v0.1.0)
 * New [TrustyAI Operator](../2023-08-18-trustyai-operator-blog) to deploy and manage TrustyAI services
 
-Notable Changes
-------
-* ODH Dashboard updated to v2.14.1
-* Data Science Pipelines updated to v1.2.0
-* KServe manifests v0.11.0 available with new operator.
-* TrustyAI 
+**NOTE:** Please review the [odh-operator v2.0 blog](../2023-07-24-odh-operator-v2.0-blog) to learn more about the new `DataScienceCluster` CustomResourceDefinition that will be replacing the `KfDef` deployment method in an future release
 
 The following is a list of components that are available in [v1.9.0](https://github.com/opendatahub-io/odh-manifests/releases/tag/v1.9.0) release of odh-manifests:
 


### PR DESCRIPTION
Update the ODH v1.9.0 announcement to remove the redundant notable changes. Add a reminder to users about the alpha release of odh-operator v2.x