### PR TITLE
Workaround gatsby/something stripping space before the <span> element

### DIFF
--- a/src/components/pages/home/CompetitiveAdvantage.tsx
+++ b/src/components/pages/home/CompetitiveAdvantage.tsx
@@ -155,8 +155,9 @@ export const CompetitiveAdvantage = (
               </StackItem>
               <StackItem>
                 <Text component={TextVariants.p}>
-                  An improved user experience allows application developers and data scientists to orchestrate workflows,
-                  <span className="strong-text">train and serve models</span>, and build AI-infused applications faster than ever.
+                  An improved user experience allows application developers and data scientists
+                  to orchestrate workflows, <span className="strong-text">train and serve models</span>, and
+                  build AI-infused applications faster than ever.
                 </Text>
               </StackItem>
             </Stack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The home page is missing space after comma, even if the source has a newline there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
host$ podman run --rm -ti registry.fedoraproject.org/fedora
container# dnf install -y npm git-core g++ patch
container# git clone https://github.com/opendatahub-io/opendatahub.io.git
container# cd opendatahub.io/
container# npm ci
container# npm run build
container# grep -r 'to orchestrate workflows,<span' public
container# grep -r 'to orchestrate workflows, <span' public
container# patch -p1
container# npm run build
container# grep -r 'to orchestrate workflows,<span' public
container# grep -r 'to orchestrate workflows, <span' public
```

Without the patch, the grep without space after comma outputs a looong line.

With the patch, the grep with space after comma outputs a looong line.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
