### PR TITLE
ds-docs-navbar-update

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -16,12 +16,20 @@ export const DOCS_NAVIGATION: SideNavItemConfig[] = [
         slug: "/docs/working-on-data-science-projects/"
     },
     {
+        title: "Monitoring data science models ",
+        slug: "/docs/monitoring-data-science-models/"
+    },
+    {
         title: "Managing users",
         slug: "/docs/managing-users/"
     },
     {
         title: "Managing resources",
         slug: "/docs/managing-resources/"
+    },
+    {
+        title: "Monitoring performance metrics",
+        slug: "/docs/monitoring-performance-metrics/"
     },
     {
         title: "Architecture",

--- a/src/templates/docs-page.tsx
+++ b/src/templates/docs-page.tsx
@@ -17,7 +17,7 @@ const DocsPageTemplate = ({
         return {
           ...prev,
           [curr.fields.slug]: curr.sections.filter(
-            (section) => section?.level && section.level <= 1
+            (section) => section?.level && section.level <= 2
           ),
         };
       } else {


### PR DESCRIPTION
Updated the Open Data Hub doc's left navigation bar to:

- Include two new guides "Monitoring data science models" and "Monitoring performance metrics"
- Include level 2 headings 