### PR TITLE
ds-docs-navbar-edit

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -28,10 +28,6 @@ export const DOCS_NAVIGATION: SideNavItemConfig[] = [
         slug: "/docs/managing-resources/"
     },
     {
-        title: "Monitoring performance metrics",
-        slug: "/docs/monitoring-performance-metrics/"
-    },
-    {
         title: "Architecture",
         slug: "/docs/architecture"
     },


### PR DESCRIPTION
removing "Monitoring performance metrics" from the left navbar -
added doc prematurely - this feature not yet in the ODH UI