### PR TITLE
fix: set v2 as default since it is on G.A

### DIFF
--- a/src/content/blog/2023-11-03-odh-release-2.4.0-blog.md
+++ b/src/content/blog/2023-11-03-odh-release-2.4.0-blog.md
@@ -13,7 +13,7 @@ Changes included in the Open Data Hub v2.4.0 release:
 
 * ODH Operator
 
-  * **fast channel**(alpha): [v2.4.0](https://github.com/opendatahub-io/opendatahub-operator/releases/tag/v2.4.0)
+  * **fast channel**(default): [v2.4.0](https://github.com/opendatahub-io/opendatahub-operator/releases/tag/v2.4.0)
 * ODH Dashboard [v2.17.0-incubation](https://github.com/opendatahub-io/odh-dashboard/releases/tag/v2.17.0-incubation)
 * Data Science Pipelines Operator [v1.6.0](https://github.com/opendatahub-io/data-science-pipelines/releases/tag/v1.6.0)
 * ODH Notebook Controller [v1.7.0-5](https://github.com/opendatahub-io/kubeflow/releases/tag/v1.7.0-5)
@@ -25,7 +25,9 @@ Changes included in the Open Data Hub v2.4.0 release:
 
 **NOTE:** Please review the [odh-operator v2.0 blog](../2023-07-24-odh-operator-v2.0-blog) to learn more about the new `DataScienceCluster` CustomResourceDefinition that is replacing the `KfDef` deployment method.
 
+
 **NOTE2:** Rolling channel will keep v1.11.0 as the last release for a while.
+
 Notable Changes
 ------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
to correct wrong info on previous releasenotes: https://opendatahub.io/blog/2023-11-03-odh-release-2.4.0-blog/
and format

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
