### PR TITLE
Update gatsby-config.ts to reference v2.4 documentation release tag

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `main`,
+        branch: `v2.4`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Move to release-based documentation builds.
