### PR TITLE
Update docs to 2.5 release tag

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.4`,
+        branch: `v2.5`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Update `gatsby-config.ts` to point docs to the 2.5 release tag in https://github.com/opendatahub-io/opendatahub-documentation.