### PR TITLE
Add model-serving guide to left navigation menu

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -20,7 +20,11 @@ export const DOCS_NAVIGATION: SideNavItemConfig[] = [
         slug: "/docs/working-on-data-science-projects/"
     },
     {
-        title: "Monitoring data science models ",
+        title: "Serving models",
+        slug: "/docs/serving-models/"
+    }, 
+    {
+        title: "Monitoring data science models",
         slug: "/docs/monitoring-data-science-models/"
     },
     {


### PR DESCRIPTION
Add model serving guide to left navigation menu.

Tested with local build of the ODH site.