### PR TITLE
Point docs to 2.6.1 documentation release

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.6`,
+        branch: `v2.6.1`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Point to 2.6.1 documentation release to pick up a handful of minor post-2.6 updates.