### PR TITLE
Point to documentation for 2.8 release

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.7`,
+        branch: `v2.8`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Point docs build to `v2.8` release tag.
