### PR TITLE
Point to documentation for 2.9 release

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.8`,
+        branch: `v2.9`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Point docs build to `v2.9` release tag.