### PR TITLE
Point to documentation for 2.11 release

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.10.1`,
+        branch: `v2.11`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
The v2.11 opendatahub-documentation release is available. This PR points to it.