### PR TITLE
Add an alert to point users to the correct relese notes.

### DIFF
--- a/src/templates/docs-page.tsx
+++ b/src/templates/docs-page.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { Footer, Layout, Seo, SideNavigation } from "../components/shared";
 import { DOCS_NAVIGATION } from "../const";
-import { PageSection, Title } from "@patternfly/react-core";
+import { PageSection, Title, Alert } from "@patternfly/react-core";
 import { AsciiDocSection } from "../types";
 
 const DocsPageTemplate = ({
@@ -41,6 +41,12 @@ const DocsPageTemplate = ({
         isWidthLimited
         padding={{ default: "padding" }}
       >
+        <Alert variant="info" title="Important Notice" isInline className="pf-u-mb-xl">
+          <p>
+            Please note that more information about the previous v2 releases can be found <a href="https://github.com/opendatahub-io/opendatahub-operator/releases" target="_blank" rel="noopener noreferrer">here</a>.
+            You can use "Find a release" search bar to search for a particular release.
+          </p>
+        </Alert>
         <Title headingLevel="h1" size="4xl">{asciidoc?.document?.title ?? markdownRemark?.frontmatter?.title}</Title>
         <div
           className="asciidoc-docs"


### PR DESCRIPTION
Provide a message to users about the latest release notes.

## Description
After some discussion with the team, it seems that the information about a release should have a singe source of truth and that being the https://github.com/opendatahub-io/opendatahub-operator/releases/latest.
So the idea is to provide a useful notice to the users so that they can navigate to the correct one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
