### PR TITLE
Point to docs changes for 2.16 release

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.15`,
+        branch: `v2.16`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Updates gatsby-config.ts to point to the latest release tag for the ODH docs updates that correspond to RHOAI 2.16.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
