### PR TITLE
Point to documentation for 2.18 release

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.17`,
+        branch: `v2.18`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Updates gatsby-config.ts to point to the v2.18 branch for the ODH docs updates that correspond to RHOAI 2.18.