### PR TITLE
[ccs] Point to docs branch for 2.19 release.

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.18`,
+        branch: `v2.19`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Updates gatsby-config.ts to point to the latest docs branch: https://github.com/opendatahub-io/opendatahub-documentation/tree/v2.19 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
