### PR TITLE
Publishing 2.23 for Upstream

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,7 +70,7 @@ const config: GatsbyConfig = {
       options: {
         name: `docs`,
         remote: `https://github.com/opendatahub-io/opendatahub-documentation.git`,
-        branch: `v2.22`,
+        branch: `v2.23`,
         local: "public/static/docs",
       },
     },


### PR DESCRIPTION
Point to documentation for 2.23 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the site to pull and display documentation from the v2.23 branch, ensuring users see the latest docs.
  * No changes to UI or app functionality; content only refreshed.

* **Chores**
  * Adjusted configuration to track the v2.23 documentation branch for content sourcing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->