### PR TITLE
Add gen AI playground guide to documentation TOC

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -36,8 +36,8 @@ export const DOCS_NAVIGATION: SideNavItemConfig[] = [
         slug: "/docs/deploying-models/"
     },
     {
-    	title: "Experimenting with models in the gen AI playground",
-    	slug: "/docs/experimenting-with-models-in-the-gen-ai-playground/"
+        title: "Experimenting with models in the gen AI playground",
+        slug: "/docs/experimenting-with-models-in-the-gen-ai-playground/"
     },
     {
         title: "Configuring your model-serving platform",

--- a/src/const.ts
+++ b/src/const.ts
@@ -36,6 +36,10 @@ export const DOCS_NAVIGATION: SideNavItemConfig[] = [
         slug: "/docs/deploying-models/"
     },
     {
+    	title: "Experimenting with models in the gen AI playground",
+    	slug: "/docs/experimenting-with-models-in-the-gen-ai-playground/"
+    },
+    {
         title: "Configuring your model-serving platform",
         slug: "/docs/configuring-your-model-serving-platform/"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding the playground guide to the TOC

The **Experimenting with models in the gen AI playground** guide was missing from the TOC; this PR adds it.
 @Gkrumbach07 @VaishnaviHire or @zdtsw please review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation section on experimenting with models in the gen AI playground, now available in the documentation menu.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->