### PR TITLE
fix: clear cached git-sourced docs before build

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       
+      - name: Clear cached git-sourced docs
+        run: rm -rf public/static/docs
+      
       - name: Build with Gatsby
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       


### PR DESCRIPTION
## Problem

The `Deploy Gatsby site to Pages` workflow has been failing with:

```
fatal: ambiguous argument 'origin/v3.0': unknown revision or path not in the working tree.
```

Followed by:
```
Cannot query field "childAsciidoc" on type "File".
```

## Root Cause

The `gatsby-source-git` plugin clones the external documentation repository into `public/static/docs`. When GitHub Actions restores the cached `public` folder from a previous build, the plugin attempts to update the existing git repo instead of doing a fresh clone. This fails because the cached git repo is in a corrupted/stale state.

## Solution

Added a step to clear `public/static/docs` before the Gatsby build runs, ensuring a fresh clone of the documentation repository every time.

## Testing

- ✅ Build works locally
- The fix ensures `gatsby-source-git` always starts fresh rather than trying to update a cached repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the deployment pipeline to clear cached documentation before each build, ensuring fresher content is deployed with each release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->