### PR TITLE
rhoai-49316 add banner that notifies archiving of ODH doc

### DIFF
--- a/src/templates/docs-page.tsx
+++ b/src/templates/docs-page.tsx
@@ -43,8 +43,8 @@ const DocsPageTemplate = ({
       >
         <Alert variant="info" title="Important Notice" isInline className="pf-u-mb-xl">
           <p>
-            The Open Data Hub documentation and the `opendatahub-documentation` repository are archived as of March 2026.
-            To see the latest documentation, go to: <a href="https://github.com/opendatahub-io/opendatahub-operator/releases" target="_blank" rel="noopener noreferrer">Red Hat OpenShift AI Self-Managed documentation</a>.
+            The Open Data Hub documentation and the <code>opendatahub-documentation</code> repository are archived as of March 2026.
+            To see the latest documentation, go to: <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/" target="_blank" rel="noopener noreferrer">Red Hat OpenShift AI Self-Managed documentation</a>.
           </p>
         </Alert>
         <Title headingLevel="h1" size="4xl">{asciidoc?.document?.title ?? markdownRemark?.frontmatter?.title}</Title>

--- a/src/templates/docs-page.tsx
+++ b/src/templates/docs-page.tsx
@@ -43,8 +43,8 @@ const DocsPageTemplate = ({
       >
         <Alert variant="info" title="Important Notice" isInline className="pf-u-mb-xl">
           <p>
-            Please note that more information about the previous v2 releases can be found <a href="https://github.com/opendatahub-io/opendatahub-operator/releases" target="_blank" rel="noopener noreferrer">here</a>.
-            You can use "Find a release" search bar to search for a particular release.
+            The Open Data Hub documentation and the `opendatahub-documentation` repository are archived as of March 2026.
+            To see the latest documentation, go to: <a href="https://github.com/opendatahub-io/opendatahub-operator/releases" target="_blank" rel="noopener noreferrer">Red Hat OpenShift AI Self-Managed documentation</a>.
           </p>
         </Alert>
         <Title headingLevel="h1" size="4xl">{asciidoc?.document?.title ?? markdownRemark?.frontmatter?.title}</Title>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Important Notice” on the docs page to state Open Data Hub documentation is archived as of March 2026
  * Replaced prior links and instructions with a pointer to Red Hat OpenShift AI Self‑Managed documentation for current information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->